### PR TITLE
Export an empty module when document unavailable.

### DIFF
--- a/spin.js
+++ b/spin.js
@@ -15,6 +15,10 @@
 }
 (this, function() {
   "use strict";
+  
+  if (typeof document === 'undefined') {
+    return;
+  }
 
   var prefixes = ['webkit', 'Moz', 'ms', 'O'] /* Vendor prefixes */
     , animations = {} /* Animation rules keyed by their name */


### PR DESCRIPTION
In an isomorphic application, it is convenient to be able to include a browser-only module even in the server context. This short-circuits the module evaluation when `document` is undefined.
